### PR TITLE
Update instructions to manually add issues to a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 **Pledge your couch to hackers!**
 
 1. Fork this repository and put in your couch and/or travel info.
-2. Other hackers can [search](https://github.com/search?q=hackercouch+berlin) to find your info.
-3. To request a stay or invite fellow hackers, open an issue in the tracker.
+2. Manually add "Issues" to your fork by clicking the "Admin" tab in your fork.
+3. Other hackers can [search](https://github.com/search?q=hackercouch+berlin) to find your info.
+4. To request a stay or invite fellow hackers, open an issue in the tracker.
 
 It’s like CouchSurfing, except CouchSurfing sucks. So does AirBnB, hostels and hotels. Why not stay with fellow hackers when traveling?
 


### PR DESCRIPTION
I think it was intended to have an issues queue per fork, rather than just on the original owners queue. I was confused at first since this seemed the most logical, but Issues aren't enabled by default on forks.
